### PR TITLE
Svm/universal address crate

### DIFF
--- a/svm/Cargo.lock
+++ b/svm/Cargo.lock
@@ -1497,7 +1497,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "tokio",
- "universal-address",
+ "universal-address 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2392,7 +2392,7 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "endpoint",
- "universal-address",
+ "universal-address 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2406,7 +2406,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "tokio",
- "universal-address",
+ "universal-address 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5736,6 +5736,15 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "universal-address"
 version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+]
+
+[[package]]
+name = "universal-address"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f5a7a961cad0921dd50f95fa94dafdbac0e8ffef1446b7f595d928ee6b7181b"
 dependencies = [
  "anchor-lang",
 ]

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -14,9 +14,7 @@ solana-program-test = "1.18.17"
 solana-program-runtime = "1.18.17"
 solana-sdk = "1.18"
 tokio = { version = "1.14.1", features = ["full"] }
-
-[workspace.dependencies.universal-address]
-path = "modules/universal-address"
+universal-address = "0.1.0"
 
 [workspace.dependencies.endpoint]
 path = "programs/endpoint"

--- a/svm/modules/universal-address/Cargo.toml
+++ b/svm/modules/universal-address/Cargo.toml
@@ -3,6 +3,9 @@ name = "universal-address"
 version = "0.1.0"
 edition = "2021"
 description = "Universal address format for cross-chain messaging"
+license = "Apache-2.0"
+repository = "https://github.com/wormholelabs-xyz/example-messaging-endpoint"
+authors = ["Bing <bingyu.yap.21@gmail.com>"]
 
 [dependencies]
 anchor-lang = "0.30.1"

--- a/svm/programs/endpoint/src/instructions/attest_message.rs
+++ b/svm/programs/endpoint/src/instructions/attest_message.rs
@@ -13,7 +13,7 @@ pub struct AttestMessageArgs {
     pub adapter_program_id: Pubkey,
     pub adapter_pda_bump: u8,
     pub src_chain: u16,
-    pub src_addr: UniversalAddress,
+    pub src_addr: [u8; 32],
     pub sequence: u64,
     pub dst_chain: u16,
     pub integrator_program_id: Pubkey,
@@ -70,7 +70,7 @@ pub struct AttestMessage<'info> {
                 args.src_addr,
                 args.sequence,
                 args.dst_chain,
-                UniversalAddress::from_pubkey(&args.integrator_program_id),
+                args.integrator_program_id.to_bytes(),
                 args.payload_hash
             )
         ],
@@ -88,6 +88,7 @@ pub struct AttestMessage<'info> {
 /// 2. Initializes the attestation info account if it's newly created.
 /// 3. Checks if the adapter has already attested to this message.
 /// 4. Marks the adapter as having attested to the message.
+/// 5. Increases the number of attested in `attestation_info`.
 ///
 /// # Arguments
 ///
@@ -144,7 +145,7 @@ pub fn attest_message(ctx: Context<AttestMessage>, args: AttestMessageArgs) -> R
             args.src_addr,
             args.sequence,
             args.dst_chain,
-            UniversalAddress::from_pubkey(&args.integrator_program_id),
+            args.integrator_program_id.to_bytes(),
             args.payload_hash,
         )?);
     }
@@ -163,10 +164,13 @@ pub fn attest_message(ctx: Context<AttestMessage>, args: AttestMessageArgs) -> R
         .attested_adapters
         .set(adapter_info.index, true)?;
 
+    // Increment the number of attestations (saturates at 255)
+    attestation_info.num_attested = attestation_info.num_attested.saturating_add(1);
+
     emit_cpi!(MessageAttestedTo {
         message_hash: attestation_info.message_hash,
         src_chain: args.src_chain,
-        src_addr: args.src_addr,
+        src_addr: UniversalAddress::from_bytes(args.src_addr),
         sequence: args.sequence,
         dst_chain: args.dst_chain,
         dst_addr: UniversalAddress::from_pubkey(&args.integrator_program_id),

--- a/svm/programs/endpoint/src/instructions/exec_message.rs
+++ b/svm/programs/endpoint/src/instructions/exec_message.rs
@@ -7,7 +7,7 @@ use crate::{error::EndpointError, event::MessageExecuted, state::AttestationInfo
 pub struct ExecMessageArgs {
     pub integrator_program_pda_bump: u8,
     pub src_chain: u16,
-    pub src_addr: UniversalAddress,
+    pub src_addr: [u8; 32],
     pub sequence: u64,
     pub dst_chain: u16,
     pub integrator_program_id: Pubkey,
@@ -43,7 +43,7 @@ pub struct ExecMessage<'info> {
                 args.src_addr,
                 args.sequence,
                 args.dst_chain,
-                UniversalAddress::from_pubkey(&args.integrator_program_id),
+                args.integrator_program_id.to_bytes(),
                 args.payload_hash
             )
         ],
@@ -100,7 +100,7 @@ pub fn exec_message(ctx: Context<ExecMessage>, args: ExecMessageArgs) -> Result<
             args.src_addr,
             args.sequence,
             args.dst_chain,
-            UniversalAddress::from_pubkey(&args.integrator_program_id),
+            args.integrator_program_id.to_bytes(),
             args.payload_hash,
         )?);
     }
@@ -111,7 +111,7 @@ pub fn exec_message(ctx: Context<ExecMessage>, args: ExecMessageArgs) -> Result<
     emit_cpi!(MessageExecuted {
         message_hash: attestation_info.message_hash,
         src_chain: args.src_chain,
-        src_addr: args.src_addr,
+        src_addr: UniversalAddress::from_bytes(args.src_addr),
         sequence: args.sequence,
         dst_chain: args.dst_chain,
         dst_addr: UniversalAddress::from_pubkey(&args.integrator_program_id),

--- a/svm/programs/endpoint/src/instructions/pick_up_message.rs
+++ b/svm/programs/endpoint/src/instructions/pick_up_message.rs
@@ -4,6 +4,7 @@ use crate::{
     state::{AdapterInfo, OutboxMessage},
 };
 use anchor_lang::prelude::*;
+use universal_address::UniversalAddress;
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct PickUpMessageArgs {
@@ -28,7 +29,7 @@ pub struct PickUpMessage<'info> {
     #[account(
         seeds = [
             AdapterInfo::SEED_PREFIX,
-            outbox_message.src_addr.to_pubkey().as_ref(),
+            outbox_message.src_addr.as_ref(),
             args.adapter_program_id.as_ref(),
         ],
         bump = adapter_info.bump,
@@ -105,10 +106,10 @@ pub fn pick_up_message(ctx: Context<PickUpMessage>, args: PickUpMessageArgs) -> 
         .set(adapter_index, false)?;
 
     emit_cpi!(MessagePickedUp {
-        src_addr: outbox_message.src_addr,
+        src_addr: UniversalAddress::from_bytes(outbox_message.src_addr),
         sequence: outbox_message.sequence,
         dst_chain: outbox_message.dst_chain,
-        dst_addr: outbox_message.dst_addr,
+        dst_addr: UniversalAddress::from_bytes(outbox_message.dst_addr),
         payload_hash: outbox_message.payload_hash,
         adapter: args.adapter_program_id,
         remaining_adapters: outbox_message.outstanding_adapters.as_value(),

--- a/svm/programs/endpoint/src/instructions/recv_message.rs
+++ b/svm/programs/endpoint/src/instructions/recv_message.rs
@@ -11,7 +11,7 @@ use crate::{
 pub struct RecvMessageArgs {
     pub integrator_program_pda_bump: u8,
     pub src_chain: u16,
-    pub src_addr: UniversalAddress,
+    pub src_addr: [u8; 32],
     pub sequence: u64,
     pub dst_chain: u16,
     pub integrator_program_id: Pubkey,
@@ -57,7 +57,7 @@ pub struct RecvMessage<'info> {
                 args.src_addr,
                 args.sequence,
                 args.dst_chain,
-                UniversalAddress::from_pubkey(&args.integrator_program_id),
+                args.integrator_program_id.to_bytes(),
                 args.payload_hash
             )
         ],
@@ -121,10 +121,10 @@ pub fn recv_message(ctx: Context<RecvMessage>, _args: RecvMessageArgs) -> Result
     emit_cpi!(MessageReceived {
         message_hash: attestation_info.message_hash,
         src_chain: attestation_info.src_chain,
-        src_addr: attestation_info.src_addr,
+        src_addr: UniversalAddress::from_bytes(attestation_info.src_addr),
         sequence: attestation_info.sequence,
         dst_chain: attestation_info.dst_chain,
-        dst_addr: attestation_info.dst_addr,
+        dst_addr: UniversalAddress::from_bytes(attestation_info.dst_addr),
         payload_hash: attestation_info.payload_hash,
         enabled_bitmap: ctx
             .accounts

--- a/svm/programs/endpoint/src/instructions/send_message.rs
+++ b/svm/programs/endpoint/src/instructions/send_message.rs
@@ -12,7 +12,7 @@ pub struct SendMessageArgs {
     pub integrator_program_id: Pubkey,
     pub integrator_program_pda_bump: u8,
     pub dst_chain: u16,
-    pub dst_addr: UniversalAddress,
+    pub dst_addr: [u8; 32],
     pub payload_hash: [u8; 32],
 }
 
@@ -106,7 +106,7 @@ pub fn send_message(ctx: Context<SendMessage>, args: SendMessageArgs) -> Result<
 
     // Create and initialize the outbox message
     ctx.accounts.outbox_message.set_inner(OutboxMessage {
-        src_addr: UniversalAddress::from(args.integrator_program_id),
+        src_addr: args.integrator_program_id.to_bytes(),
         sequence: ctx.accounts.sequence_tracker.next_sequence(),
         dst_chain: args.dst_chain,
         dst_addr: args.dst_addr,
@@ -118,7 +118,7 @@ pub fn send_message(ctx: Context<SendMessage>, args: SendMessageArgs) -> Result<
     emit_cpi!(MessageSent {
         sender: UniversalAddress::from(args.integrator_program_id),
         sequence: ctx.accounts.sequence_tracker.sequence,
-        recipient: args.dst_addr,
+        recipient: UniversalAddress::from_bytes(args.dst_addr),
         recipient_chain: args.dst_chain,
         payload_digest: args.payload_hash,
     });

--- a/svm/programs/endpoint/src/state/outbox_message.rs
+++ b/svm/programs/endpoint/src/state/outbox_message.rs
@@ -7,7 +7,7 @@ use crate::utils::bitmap::Bitmap;
 #[account]
 pub struct OutboxMessage {
     /// The sending integrator as a 32-byte universal address
-    pub src_addr: UniversalAddress,
+    pub src_addr: [u8; 32],
 
     /// The sequence number of the message
     pub sequence: u64,
@@ -16,7 +16,7 @@ pub struct OutboxMessage {
     pub dst_chain: u16,
 
     /// The destination address as a 32-byte universal address
-    pub dst_addr: UniversalAddress,
+    pub dst_addr: [u8; 32],
 
     /// The keccak256 of an arbitrary payload (32 bytes)
     pub payload_hash: [u8; 32],

--- a/svm/programs/mock-adapter/src/lib.rs
+++ b/svm/programs/mock-adapter/src/lib.rs
@@ -3,7 +3,6 @@ use endpoint::cpi::accounts::{AttestMessage, PickUpMessage};
 use endpoint::instructions::{AttestMessageArgs, PickUpMessageArgs};
 use endpoint::program::Endpoint;
 use endpoint::{self};
-use universal_address::UniversalAddress;
 
 // Declare the program ID for the mock adapter
 declare_id!("5k8XySmYJ6nQTF8ZFZtRoevjCx9Y9PS5MT9oJDLNA162");
@@ -127,7 +126,7 @@ impl<'info> InvokePickUpMessage<'info> {
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct InvokeAttestMessageArgs {
     pub src_chain: u16,
-    pub src_addr: UniversalAddress,
+    pub src_addr: [u8; 32],
     pub sequence: u64,
     pub dst_chain: u16,
     pub integrator_program_id: Pubkey,

--- a/svm/programs/mock-integrator/src/lib.rs
+++ b/svm/programs/mock-integrator/src/lib.rs
@@ -48,7 +48,7 @@ pub mod mock_integrator {
                 integrator_program_id: crate::ID,
                 integrator_program_pda_bump: ctx.bumps.integrator_program_pda,
                 dst_chain: args.dst_chain,
-                dst_addr: args.dst_addr,
+                dst_addr: args.dst_addr.to_bytes(),
                 payload_hash: args.payload_hash,
             },
         )?;

--- a/svm/programs/mock-integrator/tests/attest_message.rs
+++ b/svm/programs/mock-integrator/tests/attest_message.rs
@@ -17,7 +17,6 @@ use solana_program_test::*;
 use solana_sdk::{
     instruction::InstructionError, signature::Keypair, transaction::TransactionError,
 };
-use universal_address::UniversalAddress;
 
 async fn setup_test_environment(
     chain_id: u16,
@@ -109,10 +108,10 @@ async fn test_attest_message_success() {
     ) = setup_test_environment(2).await;
 
     let src_chain: u16 = chain_id;
-    let src_addr = UniversalAddress::from_bytes([1u8; 32]);
+    let src_addr = [1u8; 32];
     let sequence: u64 = 1;
     let dst_chain = 1;
-    let dst_addr = UniversalAddress::from_pubkey(&mock_integrator::id());
+    let dst_addr = mock_integrator::id().to_bytes();
     let payload_hash = [3u8; 32];
 
     let result = attest_message(
@@ -149,6 +148,7 @@ async fn test_attest_message_success() {
     assert_eq!(attestation_info.dst_chain, dst_chain);
     assert_eq!(attestation_info.dst_addr, dst_addr);
     assert_eq!(attestation_info.payload_hash, payload_hash);
+    assert_eq!(attestation_info.num_attested, 1);
 
     // Verify that the adapter's bit is set in the attested_adapters bitmap
     let adapter_info: AdapterInfo = get_account(&mut context.banks_client, adapter_info_pda).await;
@@ -172,10 +172,10 @@ async fn test_attest_message_after_exec() {
     ) = setup_test_environment(2).await;
 
     let src_chain: u16 = chain_id;
-    let src_addr = UniversalAddress::from_bytes([1u8; 32]);
+    let src_addr = [1u8; 32];
     let sequence: u64 = 1;
     let dst_chain = 1;
-    let dst_addr = UniversalAddress::from_pubkey(&mock_integrator::id());
+    let dst_addr = mock_integrator::id().to_bytes();
     let payload_hash = [3u8; 32];
 
     // First execution (should succeed)
@@ -250,10 +250,10 @@ async fn test_attest_message_duplicate_attestation() {
     ) = setup_test_environment(2).await;
 
     let src_chain: u16 = chain_id;
-    let src_addr = UniversalAddress::from_bytes([1u8; 32]);
+    let src_addr = [1u8; 32];
     let sequence: u64 = 1;
     let dst_chain = 1;
-    let dst_addr = UniversalAddress::from_pubkey(&mock_integrator::id());
+    let dst_addr = mock_integrator::id().to_bytes();
     let payload_hash = [3u8; 32];
 
     // First attestation (should succeed)
@@ -313,10 +313,10 @@ async fn test_attest_message_invalid_destination_chain() {
     ) = setup_test_environment(2).await;
 
     let src_chain: u16 = chain_id;
-    let src_addr = UniversalAddress::from_bytes([1u8; 32]);
+    let src_addr = [1u8; 32];
     let sequence: u64 = 1;
     let dst_chain = 3; // Invalid destination chain
-    let dst_addr = UniversalAddress::from_pubkey(&mock_integrator::id());
+    let dst_addr = mock_integrator::id().to_bytes();
     let payload_hash = [3u8; 32];
 
     let result = attest_message(

--- a/svm/programs/mock-integrator/tests/exec_message.rs
+++ b/svm/programs/mock-integrator/tests/exec_message.rs
@@ -82,10 +82,10 @@ async fn test_exec_message_success() {
     let (mut context, payer, _, _, chain_id) = setup_test_environment().await;
 
     let src_chain: u16 = chain_id;
-    let src_addr = UniversalAddress::from_bytes([1u8; 32]);
+    let src_addr = [1u8; 32];
     let sequence: u64 = 1;
     let dst_chain = 1;
-    let dst_addr = UniversalAddress::from_pubkey(&mock_integrator::id());
+    let dst_addr = mock_integrator::id().to_bytes();
     let payload_hash = [3u8; 32];
 
     let result = exec_message(
@@ -127,10 +127,10 @@ async fn test_exec_message_duplicate_execution() {
     let (mut context, payer, _, _, chain_id) = setup_test_environment().await;
 
     let src_chain: u16 = chain_id;
-    let src_addr = UniversalAddress::from_bytes([1u8; 32]);
+    let src_addr = [1u8; 32];
     let sequence: u64 = 1;
     let dst_chain = 1;
-    let dst_addr = UniversalAddress::from_pubkey(&mock_integrator::id());
+    let dst_addr = mock_integrator::id().to_bytes();
     let payload_hash = [3u8; 32];
 
     // First execution (should succeed)
@@ -175,10 +175,10 @@ async fn test_exec_message_zero_chain_id() {
     let (mut context, payer, _, _, chain_id) = setup_test_environment().await;
 
     let src_chain: u16 = chain_id;
-    let src_addr = UniversalAddress::from_bytes([1u8; 32]);
+    let src_addr = [1u8; 32];
     let sequence: u64 = 1;
     let dst_chain = 0;
-    let dst_addr = UniversalAddress::from_pubkey(&mock_integrator::id());
+    let dst_addr = mock_integrator::id().to_bytes();
     let payload_hash = [3u8; 32];
 
     // First execution (should succeed)

--- a/svm/programs/mock-integrator/tests/instructions/attest_message.rs
+++ b/svm/programs/mock-integrator/tests/instructions/attest_message.rs
@@ -18,10 +18,10 @@ pub async fn attest_message(
     adapter_pda: Pubkey,
     integrator_chain_config: Pubkey,
     src_chain: u16,
-    src_addr: UniversalAddress,
+    src_addr: [u8; 32],
     sequence: u64,
     dst_chain: u16,
-    dst_addr: UniversalAddress,
+    dst_addr: [u8; 32],
     payload_hash: [u8; 32],
 ) -> Result<(), BanksClientError> {
     let message_hash = AttestationInfo::compute_message_hash(

--- a/svm/programs/mock-integrator/tests/instructions/exec_message.rs
+++ b/svm/programs/mock-integrator/tests/instructions/exec_message.rs
@@ -7,7 +7,6 @@ use solana_sdk::{
     pubkey::Pubkey,
     signer::{keypair::Keypair, Signer},
 };
-use universal_address::UniversalAddress;
 
 use crate::common::execute_transaction::execute_transaction;
 
@@ -15,10 +14,10 @@ pub async fn exec_message(
     context: &mut ProgramTestContext,
     payer: &Keypair,
     src_chain: u16,
-    src_addr: UniversalAddress,
+    src_addr: [u8; 32],
     sequence: u64,
     dst_chain: u16,
-    dst_addr: UniversalAddress,
+    dst_addr: [u8; 32],
     payload_hash: [u8; 32],
 ) -> Result<(), BanksClientError> {
     let (integrator_program_pda, integrator_program_pda_bump) =

--- a/svm/programs/mock-integrator/tests/instructions/recv_message.rs
+++ b/svm/programs/mock-integrator/tests/instructions/recv_message.rs
@@ -7,7 +7,6 @@ use solana_sdk::{
     pubkey::Pubkey,
     signer::{keypair::Keypair, Signer},
 };
-use universal_address::UniversalAddress;
 
 use crate::common::execute_transaction::execute_transaction;
 
@@ -16,7 +15,7 @@ pub async fn recv_message(
     payer: &Keypair,
     attestation_info: Pubkey,
     src_chain: u16,
-    src_addr: UniversalAddress,
+    src_addr: [u8; 32],
     sequence: u64,
     dst_chain: u16,
     payload_hash: [u8; 32],

--- a/svm/programs/mock-integrator/tests/recv_message.rs
+++ b/svm/programs/mock-integrator/tests/recv_message.rs
@@ -18,7 +18,6 @@ use solana_sdk::{
     instruction::InstructionError, signature::Keypair, signer::Signer,
     transaction::TransactionError,
 };
-use universal_address::UniversalAddress;
 
 async fn setup_test_environment() -> (
     ProgramTestContext,
@@ -109,10 +108,10 @@ async fn test_recv_message_success() {
     ) = setup_test_environment().await;
 
     let src_chain: u16 = chain_id;
-    let src_addr = UniversalAddress::from_bytes([1u8; 32]);
+    let src_addr = [1u8; 32];
     let sequence: u64 = 1;
     let dst_chain = 1;
-    let dst_addr = UniversalAddress::from_pubkey(&mock_integrator::id());
+    let dst_addr = mock_integrator::id().to_bytes();
     let payload_hash = [3u8; 32];
 
     // First, attest the message
@@ -190,10 +189,10 @@ async fn test_recv_message_already_executed() {
     ) = setup_test_environment().await;
 
     let src_chain: u16 = chain_id;
-    let src_addr = UniversalAddress::from_bytes([1u8; 32]);
+    let src_addr = [1u8; 32];
     let sequence: u64 = 1;
     let dst_chain = 1;
-    let dst_addr = UniversalAddress::from_pubkey(&mock_integrator::id());
+    let dst_addr = mock_integrator::id().to_bytes();
     let payload_hash = [3u8; 32];
 
     // First, attest and receive the message
@@ -264,10 +263,10 @@ async fn test_recv_message_no_attestation() {
         setup_test_environment().await;
 
     let src_chain: u16 = chain_id;
-    let src_addr = UniversalAddress::from_bytes([1u8; 32]);
+    let src_addr = [1u8; 32];
     let sequence: u64 = 1;
     let dst_chain = 1;
-    let dst_addr = UniversalAddress::from_pubkey(&mock_integrator::id());
+    let dst_addr = mock_integrator::id().to_bytes();
     let payload_hash = [3u8; 32];
 
     let (attestation_info_pda, _) = AttestationInfo::pda(AttestationInfo::compute_message_hash(

--- a/svm/programs/mock-integrator/tests/send_message.rs
+++ b/svm/programs/mock-integrator/tests/send_message.rs
@@ -131,12 +131,12 @@ async fn test_send_message_success() {
     let outbox_msg: OutboxMessage =
         get_account(&mut context.banks_client, outbox_message.pubkey()).await;
     assert_eq!(
-        outbox_msg.src_addr,
-        UniversalAddress::from(mock_integrator::id())
+        &outbox_msg.src_addr[..],
+        &mock_integrator::id().to_bytes()[..]
     );
     assert_eq!(outbox_msg.sequence, 0);
     assert_eq!(outbox_msg.dst_chain, chain_id);
-    assert_eq!(outbox_msg.dst_addr, dst_addr);
+    assert_eq!(outbox_msg.dst_addr, dst_addr.to_bytes());
     assert_eq!(outbox_msg.payload_hash, payload_hash);
     assert_eq!(outbox_msg.outstanding_adapters.as_value(), 1);
 }


### PR DESCRIPTION
This PR does the below: 
1. use `universal-address` from crate instead of a module
2. use `[u8; 32]` instead of `UniversalAddress` for parts where `Adapter` program is involved for `declare_program` macro to work cleanly
3. add `num_attested` field to `AttestationInfo` which is incremented in `attest_message`. Test for this spec is added. 