### PR TITLE
evm: Update IAdapter to add instructions parameter

### DIFF
--- a/evm/src/Endpoint.sol
+++ b/evm/src/Endpoint.sol
@@ -393,11 +393,12 @@ contract Endpoint is IEndpointAdmin, IEndpointIntegrator, IEndpointAdapter, Mess
         // get the next sequence number for msg.sender
         sequence = _useMessageSequence(msg.sender);
         for (uint256 i = 0; i < len;) {
+            bytes memory adapterInstructions; // TODO: Pass this in.
             // quote the delivery price
-            uint256 deliveryPrice = IAdapter(sendAdapters[i]).quoteDeliveryPrice(dstChain);
+            uint256 deliveryPrice = IAdapter(sendAdapters[i]).quoteDeliveryPrice(dstChain, adapterInstructions);
             // call sendMessage
             IAdapter(sendAdapters[i]).sendMessage{value: deliveryPrice}(
-                sender, sequence, dstChain, dstAddr, payloadHash, refundAddress
+                sender, sequence, dstChain, dstAddr, payloadHash, refundAddress, adapterInstructions
             );
             unchecked {
                 ++i;
@@ -577,7 +578,8 @@ contract Endpoint is IEndpointAdmin, IEndpointIntegrator, IEndpointAdapter, Mess
         uint256 len = sendAdapters.length;
         totalCost = 0;
         for (uint256 i = 0; i < len;) {
-            totalCost += IAdapter(sendAdapters[i]).quoteDeliveryPrice(dstChain);
+            bytes memory adapterInstructions; // TODO: Pass this in.
+            totalCost += IAdapter(sendAdapters[i]).quoteDeliveryPrice(dstChain, adapterInstructions);
             unchecked {
                 ++i;
             }

--- a/evm/src/interfaces/IAdapter.sol
+++ b/evm/src/interfaces/IAdapter.sol
@@ -14,8 +14,9 @@ interface IAdapter {
 
     /// @notice Fetch the delivery price for a given recipient chain transfer.
     /// @param recipientChain The Wormhole chain ID of the target chain.
+    /// @param instructions The instructions specific to this adapter. May be null.
     /// @return deliveryPrice The cost of delivering a message to the recipient chain in this chain's native token.
-    function quoteDeliveryPrice(uint16 recipientChain) external view returns (uint256);
+    function quoteDeliveryPrice(uint16 recipientChain, bytes calldata instructions) external view returns (uint256);
 
     /// @dev Send a message to another chain.
     /// @param srcAddr The universal address of the sender.
@@ -24,12 +25,14 @@ interface IAdapter {
     /// @param dstAddr The universal address of the recipient.
     /// @param payloadHash The hash of the message to be sent to the recipient chain.
     /// @param refundAddr The address of the refund recipient.
+    /// @param instructions The instructions specific to this adapter. May be null.
     function sendMessage(
         UniversalAddress srcAddr,
         uint64 sequence,
         uint16 dstChain,
         UniversalAddress dstAddr,
         bytes32 payloadHash,
-        address refundAddr
+        address refundAddr,
+        bytes calldata instructions
     ) external payable;
 }

--- a/evm/test/Endpoint.t.sol
+++ b/evm/test/Endpoint.t.sol
@@ -46,7 +46,12 @@ contract AdapterImpl is IAdapter {
         return "test";
     }
 
-    function quoteDeliveryPrice(uint16 /*recipientChain*/ ) public view override returns (uint256) {
+    function quoteDeliveryPrice(uint16, /*recipientChain*/ bytes calldata /*instructions*/ )
+        public
+        view
+        override
+        returns (uint256)
+    {
         return _deliveryPrice;
     }
 
@@ -60,7 +65,8 @@ contract AdapterImpl is IAdapter {
         uint16, // recipientChain,
         UniversalAddress, // recipientAddress,
         bytes32, // payloadHash,
-        address // refundAddress
+        address, // refundAddress
+        bytes calldata // instructions
     ) public payable override {
         messagesSent += 1;
     }


### PR DESCRIPTION
This PR changes `IAdapter` to take the new adapter instructions parameter so I can start using it in the adapter repo. This PR doesn't add the new parameter to the `Endpoint` function since that will also require parsing the instructions, which should be handled by another PR.