### PR TITLE
evm: Add support for adapter instructions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "evm/lib/forge-std"]
 	path = evm/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "evm/lib/wormhole-solidity-sdk"]
+	path = evm/lib/wormhole-solidity-sdk
+	url = https://github.com/wormhole-foundation/wormhole-solidity-sdk

--- a/evm/script/TestIntegrator.s.sol
+++ b/evm/script/TestIntegrator.s.sol
@@ -28,7 +28,7 @@ contract TestIntegrator {
         address refundAddress = address(this);
         bytes32 payloadHash = keccak256("hello, world");
         IEndpointIntegrator(endpoint).sendMessage(
-            chain, UniversalAddressLibrary.fromAddress(dstAddr), payloadHash, refundAddress
+            chain, UniversalAddressLibrary.fromAddress(dstAddr), payloadHash, refundAddress, new bytes(0)
         );
     }
 

--- a/evm/src/Endpoint.sol
+++ b/evm/src/Endpoint.sol
@@ -384,7 +384,7 @@ contract Endpoint is IEndpointAdmin, IEndpointIntegrator, IEndpointAdapter, Mess
         returns (uint64 sequence)
     {
         // get the enabled send adapters for [msg.sender][dstChain]
-        address[] memory sendAdapters = getSendAdaptersByChain(msg.sender, dstChain);
+        PerSendAdapterInfo[] memory sendAdapters = getSendAdaptersByChain(msg.sender, dstChain);
         uint256 len = sendAdapters.length;
         if (len == 0) {
             revert AdapterNotEnabled();
@@ -395,9 +395,9 @@ contract Endpoint is IEndpointAdmin, IEndpointIntegrator, IEndpointAdapter, Mess
         for (uint256 i = 0; i < len;) {
             bytes memory adapterInstructions; // TODO: Pass this in.
             // quote the delivery price
-            uint256 deliveryPrice = IAdapter(sendAdapters[i]).quoteDeliveryPrice(dstChain, adapterInstructions);
+            uint256 deliveryPrice = IAdapter(sendAdapters[i].addr).quoteDeliveryPrice(dstChain, adapterInstructions);
             // call sendMessage
-            IAdapter(sendAdapters[i]).sendMessage{value: deliveryPrice}(
+            IAdapter(sendAdapters[i].addr).sendMessage{value: deliveryPrice}(
                 sender, sequence, dstChain, dstAddr, payloadHash, refundAddress, adapterInstructions
             );
             unchecked {
@@ -574,12 +574,12 @@ contract Endpoint is IEndpointAdmin, IEndpointIntegrator, IEndpointAdapter, Mess
     /// @param dstChain The Wormhole chain ID of the recipient.
     /// @return totalCost The total cost of delivering a message to the recipient chain in this chain's native token.
     function _quoteDeliveryPrice(address integrator, uint16 dstChain) internal view returns (uint256 totalCost) {
-        address[] memory sendAdapters = getSendAdaptersByChain(integrator, dstChain);
+        PerSendAdapterInfo[] memory sendAdapters = getSendAdaptersByChain(integrator, dstChain);
         uint256 len = sendAdapters.length;
         totalCost = 0;
         for (uint256 i = 0; i < len;) {
             bytes memory adapterInstructions; // TODO: Pass this in.
-            totalCost += IAdapter(sendAdapters[i]).quoteDeliveryPrice(dstChain, adapterInstructions);
+            totalCost += IAdapter(sendAdapters[i].addr).quoteDeliveryPrice(dstChain, adapterInstructions);
             unchecked {
                 ++i;
             }

--- a/evm/src/Endpoint.sol
+++ b/evm/src/Endpoint.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.19;
 import "./interfaces/IEndpointAdmin.sol";
 import "./interfaces/IEndpointIntegrator.sol";
 import "./interfaces/IEndpointAdapter.sol";
+import "./libraries/AdapterInstructions.sol";
 import "./MessageSequence.sol";
 import "./AdapterRegistry.sol";
 import "./interfaces/IAdapter.sol";
@@ -378,13 +379,41 @@ contract Endpoint is IEndpointAdmin, IEndpointIntegrator, IEndpointAdapter, Mess
     // =============== Message functions =======================================================
 
     /// @inheritdoc IEndpointIntegrator
-    function sendMessage(uint16 dstChain, UniversalAddress dstAddr, bytes32 payloadHash, address refundAddress)
-        external
-        payable
-        returns (uint64 sequence)
-    {
+    function sendMessage(
+        uint16 dstChain,
+        UniversalAddress dstAddr,
+        bytes32 payloadHash,
+        address refundAddress,
+        bytes calldata adapterInstructions
+    ) external payable returns (uint64 sequence) {
+        return _sendMessage(
+            SendMessageArgs({
+                dstChain: dstChain,
+                dstAddr: dstAddr,
+                payloadHash: payloadHash,
+                refundAddress: refundAddress,
+                adapterInstructions: adapterInstructions
+            })
+        );
+    }
+
+    /// @dev Used to get around "stack too deep.
+    struct SendMessageArgs {
+        uint16 dstChain;
+        UniversalAddress dstAddr;
+        bytes32 payloadHash;
+        address refundAddress;
+        bytes adapterInstructions;
+    }
+
+    function _sendMessage(SendMessageArgs memory args) internal returns (uint64 sequence) {
+        // Parse the adapter instructions so we can pass the appropriate one to each adapter.
+        AdapterInstructions.Instruction[] memory adapterInst = AdapterInstructions.parseInstructions(
+            args.adapterInstructions, _getRegisteredAdaptersStorage()[msg.sender].length
+        );
+
         // get the enabled send adapters for [msg.sender][dstChain]
-        PerSendAdapterInfo[] memory sendAdapters = getSendAdaptersByChain(msg.sender, dstChain);
+        PerSendAdapterInfo[] memory sendAdapters = getSendAdaptersByChain(msg.sender, args.dstChain);
         uint256 len = sendAdapters.length;
         if (len == 0) {
             revert AdapterNotEnabled();
@@ -393,12 +422,19 @@ contract Endpoint is IEndpointAdmin, IEndpointIntegrator, IEndpointAdapter, Mess
         // get the next sequence number for msg.sender
         sequence = _useMessageSequence(msg.sender);
         for (uint256 i = 0; i < len;) {
-            bytes memory adapterInstructions; // TODO: Pass this in.
             // quote the delivery price
-            uint256 deliveryPrice = IAdapter(sendAdapters[i].addr).quoteDeliveryPrice(dstChain, adapterInstructions);
+            uint256 deliveryPrice = IAdapter(sendAdapters[i].addr).quoteDeliveryPrice(
+                args.dstChain, adapterInst[sendAdapters[i].index].payload
+            );
             // call sendMessage
             IAdapter(sendAdapters[i].addr).sendMessage{value: deliveryPrice}(
-                sender, sequence, dstChain, dstAddr, payloadHash, refundAddress, adapterInstructions
+                sender,
+                sequence,
+                args.dstChain,
+                args.dstAddr,
+                args.payloadHash,
+                args.refundAddress,
+                adapterInst[sendAdapters[i].index].payload
             );
             unchecked {
                 ++i;
@@ -406,12 +442,12 @@ contract Endpoint is IEndpointAdmin, IEndpointIntegrator, IEndpointAdapter, Mess
         }
 
         emit MessageSent(
-            computeMessageDigest(ourChain, sender, sequence, dstChain, dstAddr, payloadHash),
+            computeMessageDigest(ourChain, sender, sequence, args.dstChain, args.dstAddr, args.payloadHash),
             sender,
             sequence,
-            dstAddr,
-            dstChain,
-            payloadHash
+            args.dstAddr,
+            args.dstChain,
+            args.payloadHash
         );
     }
 
@@ -544,13 +580,17 @@ contract Endpoint is IEndpointAdmin, IEndpointIntegrator, IEndpointAdapter, Mess
     }
 
     /// @inheritdoc IEndpointIntegrator
-    function quoteDeliveryPrice(address integrator, uint16 dstChain) external view returns (uint256) {
-        return _quoteDeliveryPrice(integrator, dstChain);
+    function quoteDeliveryPrice(address integrator, uint16 dstChain, bytes calldata adapterInstructions)
+        external
+        view
+        returns (uint256)
+    {
+        return _quoteDeliveryPrice(integrator, dstChain, adapterInstructions);
     }
 
     /// @inheritdoc IEndpointIntegrator
-    function quoteDeliveryPrice(uint16 dstChain) external view returns (uint256) {
-        return _quoteDeliveryPrice(msg.sender, dstChain);
+    function quoteDeliveryPrice(uint16 dstChain, bytes calldata adapterInstructions) external view returns (uint256) {
+        return _quoteDeliveryPrice(msg.sender, dstChain, adapterInstructions);
     }
 
     // =============== Internal ==============================================================
@@ -572,14 +612,24 @@ contract Endpoint is IEndpointAdmin, IEndpointIntegrator, IEndpointAdapter, Mess
     /// @dev This sums up all the individual sendAdapter's quoteDeliveryPrice calls.
     /// @param integrator The address of the integrator.
     /// @param dstChain The Wormhole chain ID of the recipient.
+    /// @param adapterInstructions An array of adapter instructions to be passed into the adapters.
     /// @return totalCost The total cost of delivering a message to the recipient chain in this chain's native token.
-    function _quoteDeliveryPrice(address integrator, uint16 dstChain) internal view returns (uint256 totalCost) {
+    function _quoteDeliveryPrice(address integrator, uint16 dstChain, bytes calldata adapterInstructions)
+        internal
+        view
+        returns (uint256 totalCost)
+    {
+        // Parse the adapter instructions so we can pass the appropriate one to each adapter.
+        AdapterInstructions.Instruction[] memory adapterInst = AdapterInstructions.parseInstructions(
+            adapterInstructions, _getRegisteredAdaptersStorage()[integrator].length
+        );
+
         PerSendAdapterInfo[] memory sendAdapters = getSendAdaptersByChain(integrator, dstChain);
         uint256 len = sendAdapters.length;
         totalCost = 0;
         for (uint256 i = 0; i < len;) {
-            bytes memory adapterInstructions; // TODO: Pass this in.
-            totalCost += IAdapter(sendAdapters[i].addr).quoteDeliveryPrice(dstChain, adapterInstructions);
+            totalCost +=
+                IAdapter(sendAdapters[i].addr).quoteDeliveryPrice(dstChain, adapterInst[sendAdapters[i].index].payload);
             unchecked {
                 ++i;
             }

--- a/evm/src/interfaces/IEndpointIntegrator.sol
+++ b/evm/src/interfaces/IEndpointIntegrator.sol
@@ -15,12 +15,16 @@ interface IEndpointIntegrator is IMessageSequence {
     /// @param dstChain The Wormhole chain ID of the recipient.
     /// @param dstAddr The universal address of the peer on the recipient chain.
     /// @param payloadHash keccak256 of a message to be sent to the recipient chain.
-    /// @return uint64 The sequence number of the message.
     /// @param refundAddress The source chain refund address passed to the Adapter.
-    function sendMessage(uint16 dstChain, UniversalAddress dstAddr, bytes32 payloadHash, address refundAddress)
-        external
-        payable
-        returns (uint64);
+    /// @param adapterInstructions An array of adapter instructions to be passed into the adapters.
+    /// @return uint64 The sequence number of the message.
+    function sendMessage(
+        uint16 dstChain,
+        UniversalAddress dstAddr,
+        bytes32 payloadHash,
+        address refundAddress,
+        bytes calldata adapterInstructions
+    ) external payable returns (uint64);
 
     /// @notice Receives a message and marks it as executed.
     /// @param srcChain The Wormhole chain ID of the sender.
@@ -74,13 +78,17 @@ interface IEndpointIntegrator is IMessageSequence {
     /// @dev This sums up all the individual sendAdapter's quoteDeliveryPrice calls.
     /// @param integrator The address of the integrator.
     /// @param dstChain The Wormhole chain ID of the recipient.
+    /// @param adapterInstructions An array of adapter instructions to be passed into the adapters.
     /// @return uint256 The total cost of delivering a message to the recipient chain in this chain's native token.
-    function quoteDeliveryPrice(address integrator, uint16 dstChain) external returns (uint256);
+    function quoteDeliveryPrice(address integrator, uint16 dstChain, bytes calldata adapterInstructions)
+        external
+        returns (uint256);
 
     /// @notice Retrieves the quote for message delivery.
     /// @dev This version must be called by the integrator.
     /// @dev This sums up all the individual sendAdapter's quoteDeliveryPrice calls.
     /// @param dstChain The Wormhole chain ID of the recipient.
+    /// @param adapterInstructions An array of adapter instructions to be passed into the adapters.
     /// @return uint256 The total cost of delivering a message to the recipient chain in this chain's native token.
-    function quoteDeliveryPrice(uint16 dstChain) external view returns (uint256);
+    function quoteDeliveryPrice(uint16 dstChain, bytes calldata adapterInstructions) external view returns (uint256);
 }

--- a/evm/src/libraries/AdapterInstructions.sol
+++ b/evm/src/libraries/AdapterInstructions.sol
@@ -38,7 +38,7 @@ library AdapterInstructions {
     /// @notice Encodes an adapter instruction.
     /// @param instruction The instruction to be encoded.
     /// @return encoded The encoded bytes, where the first byte is the index and the next two bytes are the instruction length.
-    function encodeInstruction(Instruction memory instruction) public pure returns (bytes memory encoded) {
+    function encodeInstruction(Instruction calldata instruction) public pure returns (bytes memory encoded) {
         if (instruction.payload.length > type(uint16).max) {
             revert PayloadTooLong(instruction.payload.length);
         }
@@ -49,7 +49,7 @@ library AdapterInstructions {
     /// @notice Encodes an array of adapter instructions.
     /// @param instructions The array of instructions to be encoded.
     /// @return address The encoded bytes, where the first byte is the number of entries.
-    function encodeInstructions(Instruction[] memory instructions) public pure returns (bytes memory) {
+    function encodeInstructions(Instruction[] calldata instructions) public pure returns (bytes memory) {
         if (instructions.length > type(uint8).max) {
             revert TooManyInstructions();
         }
@@ -69,7 +69,7 @@ library AdapterInstructions {
     /// @notice Parses a byte array into an adapter instruction.
     /// @param encoded The encoded instruction.
     /// @return instruction The parsed instruction.
-    function parseInstruction(bytes memory encoded) public pure returns (Instruction memory instruction) {
+    function parseInstruction(bytes calldata encoded) public pure returns (Instruction memory instruction) {
         uint256 offset = 0;
         (instruction, offset) = parseInstructionUnchecked(encoded, offset);
         encoded.checkLength(offset);
@@ -80,7 +80,7 @@ library AdapterInstructions {
     /// @param offset The current offset into the encoded buffer.
     /// @return instruction The parsed instruction.
     /// @return nextOffset The next index into the array (used for further parsing).
-    function parseInstructionUnchecked(bytes memory encoded, uint256 offset)
+    function parseInstructionUnchecked(bytes calldata encoded, uint256 offset)
         public
         pure
         returns (Instruction memory instruction, uint256 nextOffset)
@@ -95,7 +95,7 @@ library AdapterInstructions {
     /// @param encoded The encoded instructions.
     /// @param numRegisteredAdapters The total number of registered adapters.
     /// @return instructions A sparse array of adapter instructions, where the index into the array is the adapter index.
-    function parseInstructions(bytes memory encoded, uint256 numRegisteredAdapters)
+    function parseInstructions(bytes calldata encoded, uint256 numRegisteredAdapters)
         public
         pure
         returns (Instruction[] memory instructions)

--- a/evm/src/libraries/AdapterInstructions.sol
+++ b/evm/src/libraries/AdapterInstructions.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity >=0.8.8 <0.9.0;
+
+import "wormhole-solidity-sdk/libraries/BytesParsing.sol";
+
+library AdapterInstructions {
+    using BytesParsing for bytes;
+
+    /// @notice Error thrown when there are too many instructions in the array.
+    /// @dev Selector 0x3c46992e.
+    error TooManyInstructions();
+
+    /// @notice Error thrown when the payload length exceeds the allowed maximum.
+    /// @dev Selector 0xa3419691.
+    /// @param size The size of the payload.
+    error PayloadTooLong(uint256 size);
+
+    /// @notice Error thrown when an Adapter instruction index
+    ///         is greater than the number of registered Adapters
+    /// @dev We index from 0 so if providedIndex == numAdapters then we're out-of-bounds too
+    /// @dev Selector 0x689f5016.
+    /// @param providedIndex The index specified in the instruction
+    /// @param numAdapters The number of registered Adapters
+    error InvalidInstructionIndex(uint256 providedIndex, uint256 numAdapters);
+
+    /// @dev Variable-length Adapter-specific instruction that can be passed by the integrator to the endpoint
+    ///      and by the endpoint to the adapter.
+    ///      The index field refers to the index of the adapter that this instruction should be passed to.
+    ///      The serialization format is:
+    ///      - index - 1 byte
+    ///      - payloadLength - 2 bytes
+    ///      - payload - `payloadLength` bytes
+    struct Instruction {
+        uint8 index;
+        bytes payload;
+    }
+
+    /// @notice Encodes an adapter instruction.
+    /// @param instruction The instruction to be encoded.
+    /// @return encoded The encoded bytes, where the first byte is the index and the next two bytes are the instruction length.
+    function encodeInstruction(Instruction memory instruction) public pure returns (bytes memory encoded) {
+        if (instruction.payload.length > type(uint16).max) {
+            revert PayloadTooLong(instruction.payload.length);
+        }
+        uint16 payloadLength = uint16(instruction.payload.length);
+        encoded = abi.encodePacked(instruction.index, payloadLength, instruction.payload);
+    }
+
+    /// @notice Encodes an array of adapter instructions.
+    /// @param instructions The array of instructions to be encoded.
+    /// @return address The encoded bytes, where the first byte is the number of entries.
+    function encodeInstructions(Instruction[] memory instructions) public pure returns (bytes memory) {
+        if (instructions.length > type(uint8).max) {
+            revert TooManyInstructions();
+        }
+        uint256 instructionsLength = instructions.length;
+
+        bytes memory encoded;
+        for (uint256 i = 0; i < instructionsLength;) {
+            bytes memory innerEncoded = encodeInstruction(instructions[i]);
+            encoded = bytes.concat(encoded, innerEncoded);
+            unchecked {
+                ++i;
+            }
+        }
+        return abi.encodePacked(uint8(instructionsLength), encoded);
+    }
+
+    /// @notice Parses a byte array into an adapter instruction.
+    /// @param encoded The encoded instruction.
+    /// @return instruction The parsed instruction.
+    function parseInstruction(bytes memory encoded) public pure returns (Instruction memory instruction) {
+        uint256 offset = 0;
+        (instruction, offset) = parseInstructionUnchecked(encoded, offset);
+        encoded.checkLength(offset);
+    }
+
+    /// @notice Parses a byte array into an adapter instruction without checking for leftover bytes.
+    /// @param encoded The buffer being parsed.
+    /// @param offset The current offset into the encoded buffer.
+    /// @return instruction The parsed instruction.
+    /// @return nextOffset The next index into the array (used for further parsing).
+    function parseInstructionUnchecked(bytes memory encoded, uint256 offset)
+        public
+        pure
+        returns (Instruction memory instruction, uint256 nextOffset)
+    {
+        (instruction.index, nextOffset) = encoded.asUint8Unchecked(offset);
+        uint16 instructionLength;
+        (instructionLength, nextOffset) = encoded.asUint16Unchecked(nextOffset);
+        (instruction.payload, nextOffset) = encoded.sliceUnchecked(nextOffset, instructionLength);
+    }
+
+    /// @notice Parses a byte array into an array of adapter instructions.
+    /// @param encoded The encoded instructions.
+    /// @param numRegisteredAdapters The total number of registered adapters.
+    /// @return instructions A sparse array of adapter instructions, where the index into the array is the adapter index.
+    function parseInstructions(bytes memory encoded, uint256 numRegisteredAdapters)
+        public
+        pure
+        returns (Instruction[] memory instructions)
+    {
+        // We allocate an array with the length of the number of registered Adapters
+        // This gives us the flexibility to not have to pass instructions for Adapters that
+        // don't need them.
+        instructions = new Instruction[](numRegisteredAdapters);
+
+        if (encoded.length == 0) {
+            return instructions;
+        }
+
+        uint256 offset = 0;
+        uint256 instructionsLength;
+        (instructionsLength, offset) = encoded.asUint8Unchecked(offset);
+
+        for (uint256 i = 0; i < instructionsLength;) {
+            Instruction memory instruction;
+            (instruction, offset) = parseInstructionUnchecked(encoded, offset);
+
+            uint8 instructionIndex = instruction.index;
+
+            // Instruction index is out of bounds
+            if (instructionIndex >= numRegisteredAdapters) {
+                revert InvalidInstructionIndex(instructionIndex, numRegisteredAdapters);
+            }
+
+            instructions[instructionIndex] = instruction;
+            unchecked {
+                ++i;
+            }
+        }
+
+        encoded.checkLength(offset);
+    }
+}

--- a/evm/src/libraries/AdapterInstructions.sol
+++ b/evm/src/libraries/AdapterInstructions.sol
@@ -15,12 +15,11 @@ library AdapterInstructions {
     /// @param size The size of the payload.
     error PayloadTooLong(uint256 size);
 
-    /// @notice Error thrown when an Adapter instruction index
-    ///         is greater than the number of registered Adapters
-    /// @dev We index from 0 so if providedIndex == numAdapters then we're out-of-bounds too
+    /// @notice Error thrown when an Adapter instruction index is greater than the number of registered Adapters.
+    /// @dev We index from 0 so if providedIndex == numAdapters then we're out-of-bounds too.
     /// @dev Selector 0x689f5016.
-    /// @param providedIndex The index specified in the instruction
-    /// @param numAdapters The number of registered Adapters
+    /// @param providedIndex The index specified in the instruction.
+    /// @param numAdapters The number of registered Adapters.
     error InvalidInstructionIndex(uint256 providedIndex, uint256 numAdapters);
 
     /// @dev Variable-length Adapter-specific instruction that can be passed by the integrator to the endpoint
@@ -100,9 +99,8 @@ library AdapterInstructions {
         pure
         returns (Instruction[] memory instructions)
     {
-        // We allocate an array with the length of the number of registered Adapters
-        // This gives us the flexibility to not have to pass instructions for Adapters that
-        // don't need them.
+        // We allocate an array with the length of the number of registered Adapters.
+        // This gives us the flexibility to not have to pass instructions for Adapters that don't need them.
         instructions = new Instruction[](numRegisteredAdapters);
 
         if (encoded.length == 0) {

--- a/evm/test/AdapterInstructions.t.sol
+++ b/evm/test/AdapterInstructions.t.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import {Test, console} from "forge-std/Test.sol";
+import "../src/libraries/AdapterInstructions.sol";
+
+contract AdapterInstructionsTest is Test {
+    function setUp() public {}
+
+    function test_encodeInstruction() public {
+        // Success case.
+        bytes memory payload = "The payload";
+        bytes memory expected = abi.encodePacked(uint8(0), uint16(payload.length), payload);
+        AdapterInstructions.Instruction memory inst = AdapterInstructions.Instruction(0, payload);
+        bytes memory encoded = AdapterInstructions.encodeInstruction(inst);
+        assertEq(keccak256(expected), keccak256(encoded));
+
+        // Payload too long.
+        inst = AdapterInstructions.Instruction(0, new bytes(65537));
+        vm.expectRevert(abi.encodeWithSelector(AdapterInstructions.PayloadTooLong.selector, 65537));
+        AdapterInstructions.encodeInstruction(inst);
+    }
+
+    function test_encodeInstructions() public {
+        // Success case.
+        bytes memory expected = abi.encodePacked(
+            uint8(3),
+            uint8(0),
+            uint16(29),
+            "Instructions for adapter zero",
+            uint8(3),
+            uint16(30),
+            "Instructions for adapter three",
+            uint8(2),
+            uint16(28),
+            "Instructions for adapter two"
+        );
+
+        AdapterInstructions.Instruction[] memory insts = new AdapterInstructions.Instruction[](3);
+        insts[0] = AdapterInstructions.Instruction(0, "Instructions for adapter zero");
+        insts[1] = AdapterInstructions.Instruction(3, "Instructions for adapter three");
+        insts[2] = AdapterInstructions.Instruction(2, "Instructions for adapter two");
+        bytes memory encoded = AdapterInstructions.encodeInstructions(insts);
+        assertEq(keccak256(expected), keccak256(encoded));
+
+        // Too many instructions should revert.
+        insts = new AdapterInstructions.Instruction[](257);
+        for (uint256 idx = 0; idx < 257; ++idx) {
+            insts[idx] = AdapterInstructions.Instruction(uint8(idx), "Some instruction");
+        }
+        vm.expectRevert(abi.encodeWithSelector(AdapterInstructions.TooManyInstructions.selector));
+        encoded = AdapterInstructions.encodeInstructions(insts);
+
+        // Should be able to encode an empty array.
+        insts = new AdapterInstructions.Instruction[](0);
+        encoded = AdapterInstructions.encodeInstructions(insts);
+        assertEq(1, encoded.length);
+        assertEq(0, encoded[0]);
+    }
+
+    function test_parseInstruction() public pure {
+        AdapterInstructions.Instruction memory expected = AdapterInstructions.Instruction(0, "The payload");
+        bytes memory encoded = AdapterInstructions.encodeInstruction(expected);
+        AdapterInstructions.Instruction memory inst = AdapterInstructions.parseInstruction(encoded);
+        assertEq(expected.index, inst.index);
+        assertEq(keccak256(expected.payload), keccak256(inst.payload));
+    }
+
+    // We need this to make the coverage tool happy, even though this function was called in the previous test.
+    function test_parseInstructionUnchecked() public pure {
+        AdapterInstructions.Instruction memory expected = AdapterInstructions.Instruction(0, "The payload");
+        bytes memory encoded = AdapterInstructions.encodeInstruction(expected);
+        (AdapterInstructions.Instruction memory inst, uint256 nextOffset) =
+            AdapterInstructions.parseInstructionUnchecked(encoded, 0);
+        assertEq(expected.index, inst.index);
+        assertEq(keccak256(expected.payload), keccak256(inst.payload));
+        assertEq(encoded.length, nextOffset);
+    }
+
+    function test_parseInstructions() public {
+        // Success case.
+        bytes memory expectedInst0 = "Instructions for adapter zero";
+        bytes memory expectedInst2 = "Instructions for adapter two";
+        bytes memory expectedInst3 = "Instructions for adapter three";
+        AdapterInstructions.Instruction[] memory expected = new AdapterInstructions.Instruction[](3);
+        expected[0] = AdapterInstructions.Instruction(0, expectedInst0);
+        expected[1] = AdapterInstructions.Instruction(3, expectedInst3);
+        expected[2] = AdapterInstructions.Instruction(2, expectedInst2);
+        bytes memory encoded = AdapterInstructions.encodeInstructions(expected);
+
+        AdapterInstructions.Instruction[] memory insts = AdapterInstructions.parseInstructions(encoded, 4);
+        assertEq(4, insts.length);
+
+        assertEq(0, insts[0].index);
+        assertEq(keccak256(expectedInst0), keccak256(insts[0].payload));
+
+        // Entry one should be empty.
+        assertEq(0, insts[1].index);
+        assertEq(0, insts[1].payload.length);
+
+        assertEq(2, insts[2].index);
+        assertEq(keccak256(expectedInst2), keccak256(insts[2].payload));
+
+        assertEq(3, insts[3].index);
+        assertEq(keccak256(expectedInst3), keccak256(insts[3].payload));
+
+        // Index out of range should revert.
+        vm.expectRevert(abi.encodeWithSelector(AdapterInstructions.InvalidInstructionIndex.selector, 3, 3));
+        AdapterInstructions.parseInstructions(encoded, 3);
+
+        // Should be able to parse an encoded empty array.
+        insts = new AdapterInstructions.Instruction[](0);
+        encoded = AdapterInstructions.encodeInstructions(insts);
+        insts = AdapterInstructions.parseInstructions(encoded, 4);
+        assertEq(4, insts.length);
+        for (uint256 i = 0; i < 4; ++i) {
+            assertEq(0, insts[i].index);
+            assertEq(0, insts[i].payload.length);
+        }
+
+        // Should be able to parse a *really* empty array.
+        insts = AdapterInstructions.parseInstructions(new bytes(0), 4);
+        assertEq(4, insts.length);
+        for (uint256 i = 0; i < 4; ++i) {
+            assertEq(0, insts[i].index);
+            assertEq(0, insts[i].payload.length);
+        }
+    }
+}

--- a/evm/test/AdapterRegistry.t.sol
+++ b/evm/test/AdapterRegistry.t.sol
@@ -24,7 +24,7 @@ contract ConcreteAdapterRegistry is AdapterRegistry {
     function getEnabledSendAdaptersBitmapForChain(address integrator, uint16 chain)
         public
         view
-        returns (address[] memory adapters)
+        returns (PerSendAdapterInfo[] memory adapters)
     {
         return _getEnabledSendAdaptersArrayForChain(integrator, chain);
     }
@@ -298,9 +298,9 @@ contract AdapterRegistryTest is Test {
         adapterRegistry.addAdapter(me, adapter3);
         adapterRegistry.enableSendAdapter(me, chain2, adapter3);
         adapterRegistry.addAdapter(me, adapter4);
-        address[] memory chain1Addrs = adapterRegistry.getSendAdaptersByChain(me, chain1);
+        AdapterRegistry.PerSendAdapterInfo[] memory chain1Addrs = adapterRegistry.getSendAdaptersByChain(me, chain1);
         require(chain1Addrs.length == 2, "Wrong number of adapters enabled on chain one");
-        address[] memory chain2Addrs = adapterRegistry.getSendAdaptersByChain(me, chain2);
+        AdapterRegistry.PerSendAdapterInfo[] memory chain2Addrs = adapterRegistry.getSendAdaptersByChain(me, chain2);
         require(chain2Addrs.length == 1, "Wrong number of adapters enabled on chain two");
         adapterRegistry.enableSendAdapter(me, chain2, adapter4);
         adapterRegistry.disableSendAdapter(me, chain2, adapter3);

--- a/evm/test/AdapterRegistry.t.sol
+++ b/evm/test/AdapterRegistry.t.sol
@@ -166,7 +166,7 @@ contract AdapterRegistryTest is Test {
         assertEq(adapterRegistry.getEnabledRecvAdaptersBitmapForChain(integrator1, zeroChain), 0);
     }
 
-    // This is a redudant test, as the previous tests already cover this
+    // This is a redundant test, as the previous tests already cover this
     function test5() public view {
         // Send side
         assertEq(adapterRegistry.getRegisteredAdaptersStorage(integrator1).length, 0);

--- a/evm/test/Endpoint.t.sol
+++ b/evm/test/Endpoint.t.sol
@@ -239,7 +239,7 @@ contract EndpointTest is Test {
         vm.expectEmit(true, true, false, true);
         emit AdapterRegistry.AdapterAdded(integrator, taddr2, 2);
         endpoint.addAdapter(integrator, taddr2);
-        address[] memory adapters = endpoint.getSendAdaptersByChain(integrator, 1);
+        AdapterRegistry.PerSendAdapterInfo[] memory adapters = endpoint.getSendAdaptersByChain(integrator, 1);
         require(adapters.length == 1, "Wrong number of adapters enabled on chain one, should be 1");
         // Enable another adapter on chain one and one on chain two.
         vm.expectEmit(true, true, false, true);
@@ -255,11 +255,14 @@ contract EndpointTest is Test {
         // And verify they got set properly.
         adapters = endpoint.getSendAdaptersByChain(integrator, 1);
         require(adapters.length == 2, "Wrong number of adapters enabled on chain one");
-        require(adapters[0] == taddr1, "Wrong adapter one on chain one");
-        require(adapters[1] == taddr2, "Wrong adapter two on chain one");
+        require(adapters[0].addr == taddr1, "Wrong adapter one on chain one");
+        require(adapters[0].index == 0, "Wrong adapter index one on chain one");
+        require(adapters[1].addr == taddr2, "Wrong adapter two on chain one");
+        require(adapters[1].index == 1, "Wrong adapter index two on chain one");
         adapters = endpoint.getSendAdaptersByChain(integrator, 2);
         require(adapters.length == 1, "Wrong number of adapters enabled on chain two");
-        require(adapters[0] == taddr3, "Wrong adapter one on chain two");
+        require(adapters[0].addr == taddr3, "Wrong adapter one on chain two");
+        require(adapters[0].index == 2, "Wrong adapter index one on chain two");
         vm.expectEmit(true, true, false, true);
         emit AdapterRegistry.SendAdapterDisabledForChain(integrator, 2, taddr3);
         endpoint.disableSendAdapter(integrator, 2, taddr3);


### PR DESCRIPTION
This PR modifies `sendMessage` and `quoteDeliveryPrice` to take encoded adapter instructions. It parses them into the per-adapter instructions and passes them into the adapter functions.

To do this, it adds a new `AdapterInstructions` library along with tests for it.