### PR TITLE
evm: Track enabled chains

### DIFF
--- a/evm/src/AdapterRegistry.sol
+++ b/evm/src/AdapterRegistry.sol
@@ -1,111 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.19;
 
+import "./interfaces/IAdapterRegistry.sol";
+
 /// @title AdapterRegistry
 /// @notice This contract is responsible for handling the registration of Adapters.
-abstract contract AdapterRegistry {
-    /// @dev Information about registered adapters.
-    struct AdapterInfo {
-        // whether this adapter is registered
-        bool registered;
-        uint8 index; // the index into the integrator's adapters array
-    }
-
-    /// @dev Data maintained for each send adapter enabled for an integrator and chain.
-    struct PerSendAdapterInfo {
-        address addr;
-        uint8 index;
-    }
-
-    /// @dev Bitmap encoding the enabled adapters.
-    struct _EnabledAdapterBitmap {
-        uint128 bitmap; // MAX_ADAPTERS = 128
-    }
-
+abstract contract AdapterRegistry is IAdapterRegistry {
     uint8 constant MAX_ADAPTERS = 128;
-
-    // =============== Events ===============================================
-
-    /// @notice Emitted when an adapter is added.
-    /// @dev Topic0
-    ///      0xac0e1ca21680593c8e6fcd302536c12420131dbf0e8ee4b29e529e8a81469f21.
-    /// @param integrator The address of the integrator.
-    /// @param adapter The address of the adapter.
-    /// @param adaptersNum The current number of adapters.
-    event AdapterAdded(address integrator, address adapter, uint8 adaptersNum);
-
-    /// @notice Emitted when a send side adapter is enabled for a chain.
-    /// @dev Topic0
-    ///      0x857691e2cf3b85361da0572fc891250016a03bf7921f5dbb9c34ca3d80591336.
-    /// @param integrator The address of the integrator.
-    /// @param chain The Wormhole chain ID on which this adapter is enabled.
-    /// @param adapter The address of the adapter.
-    event SendAdapterEnabledForChain(address integrator, uint16 chain, address adapter);
-
-    /// @notice Emitted when a receive side adapter is enabled for a chain.
-    /// @dev Topic0
-    ///      0x3649cec96e246496c67087fabed01d3a6c510fec6bfcd3103dd2aedd1b637acc.
-    /// @param integrator The address of the integrator.
-    /// @param chain The Wormhole chain ID on which this adapter is enabled.
-    /// @param adapter The address of the adapter.
-    event RecvAdapterEnabledForChain(address integrator, uint16 chain, address adapter);
-
-    /// @notice Emitted when a send side adapter is removed from the endpoint.
-    /// @dev Topic0
-    ///      0xf5794741500b506041917ff318a1635659dbe538238f4e60979e3f1d29ac021a.
-    /// @param integrator The address of the integrator.
-    /// @param chain The Wormhole chain ID on which this adapter is disabled.
-    /// @param adapter The address of the adapter.
-    event SendAdapterDisabledForChain(address integrator, uint16 chain, address adapter);
-
-    /// @notice Emitted when a receive side adapter is removed from the endpoint.
-    /// @dev Topic0
-    ///      0xcf88609c95c0469dbeb39cfeaa5dcb9b389a6ec8acca2d695dd3feb2f69cffde.
-    /// @param integrator The address of the integrator.
-    /// @param chain The Wormhole chain ID on which this adapter is disabled.
-    /// @param adapter The address of the adapter.
-    event RecvAdapterDisabledForChain(address integrator, uint16 chain, address adapter);
-
-    // =============== Errors ===============================================
-
-    /// @notice Error when the caller is not the adapter.
-    /// @dev Selector: 0xd8aa0b1c.
-    /// @param caller The address of the caller.
-    error CallerNotAdapter(address caller);
-
-    /// @notice Error when the adapter is the zero address.
-    /// @dev Selector: 0x4e2165a2.
-    error InvalidAdapterZeroAddress();
-
-    /// @notice Error when the adapter is disabled.
-    /// @dev Selector: 0x3b4742ca.
-    error AdapterAlreadyDisabled(address adapter);
-
-    /// @notice Error when the number of registered adapters
-    ///         exceeds (MAX_ADAPTERS = 128).
-    /// @dev Selector: 0x5bde12c0.
-    error TooManyAdapters();
-
-    /// @notice Error when attempting to use an unregistered adapter
-    ///         that is not registered.
-    /// @dev Selector: 0xc325a1ea.
-    /// @param adapter The address of the adapter.
-    error NonRegisteredAdapter(address adapter);
-
-    /// @notice Error when attempting to use an incorrect chain.
-    /// @dev Selector: 0x587c94c3.
-    /// @param chain The id of the incorrect chain.
-    error InvalidChain(uint16 chain);
-
-    /// @notice Error when attempting to register an adapter that is already register.
-    /// @dev Selector: 0x2296d41e.
-    /// @param adapter The address of the adapter.
-    error AdapterAlreadyRegistered(address adapter);
-
-    /// @notice Error when attempting to enable an adapter that is already enabled.
-    /// @dev Selector: 0xb7b944b2.
-    /// @param adapter The address of the adapter.
-    error AdapterAlreadyEnabled(address adapter);
 
     // =============== Storage ===============================================
 
@@ -130,6 +31,12 @@ abstract contract AdapterRegistry {
     ///      mapping(address => mapping(uint16 => uint128)).
     bytes32 private constant ENABLED_RECV_ADAPTER_BITMAP_SLOT =
         bytes32(uint256(keccak256("registry.recvAdapterBitmap")) - 1);
+
+    /// @dev Holds mapping of integrator address => array of chains with adapters enabled for sending.
+    bytes32 private constant SEND_ENABLED_CHAINS_SLOT = bytes32(uint256(keccak256("registry.sendEnabledChains")) - 1);
+
+    /// @dev Holds mapping of integrator address => array of chains with adapters enabled for receiving.
+    bytes32 private constant RECV_ENABLED_CHAINS_SLOT = bytes32(uint256(keccak256("registry.recvEnabledChains")) - 1);
 
     // =============== Mappings ===============================================
 
@@ -173,6 +80,15 @@ abstract contract AdapterRegistry {
     ///      Contains all registered adapters for this integrator.
     function _getRegisteredAdaptersStorage() internal pure returns (mapping(address => address[]) storage $) {
         uint256 slot = uint256(REGISTERED_ADAPTERS_SLOT);
+        assembly ("memory-safe") {
+            $.slot := slot
+        }
+    }
+
+    /// @dev Integrator address => chainID[] mapping.
+    ///      Contains all chains that have adapters enabled for this integrator.
+    function _getChainsEnabledStorage(bytes32 tag) internal pure returns (mapping(address => uint16[]) storage $) {
+        uint256 slot = uint256(tag);
         assembly ("memory-safe") {
             $.slot := slot
         }
@@ -242,9 +158,11 @@ abstract contract AdapterRegistry {
             revert AdapterAlreadyEnabled(adapter);
         }
         uint8 index = _getAdapterInfosStorage()[integrator][adapter].index;
-        mapping(address => mapping(uint16 => PerSendAdapterInfo[])) storage sendAdapterArray =
-            _getPerChainSendAdapterArrayStorage();
-        sendAdapterArray[integrator][chain].push(PerSendAdapterInfo({addr: adapter, index: index}));
+        PerSendAdapterInfo[] storage sendAdapterArray = _getPerChainSendAdapterArrayStorage()[integrator][chain];
+        if (sendAdapterArray.length == 0) {
+            _addEnabledChain(SEND_ENABLED_CHAINS_SLOT, integrator, chain);
+        }
+        sendAdapterArray.push(PerSendAdapterInfo({addr: adapter, index: index}));
         emit SendAdapterEnabledForChain(integrator, chain, adapter);
     }
 
@@ -261,9 +179,11 @@ abstract contract AdapterRegistry {
             revert AdapterAlreadyEnabled(adapter);
         }
         uint8 index = _getAdapterInfosStorage()[integrator][adapter].index;
-        mapping(address => mapping(uint16 => _EnabledAdapterBitmap)) storage _bitmaps =
-            _getPerChainRecvAdapterBitmapStorage();
-        _bitmaps[integrator][chain].bitmap |= uint128(1 << index);
+        _EnabledAdapterBitmap storage _bitmapEntry = _getPerChainRecvAdapterBitmapStorage()[integrator][chain];
+        if (_bitmapEntry.bitmap == 0) {
+            _addEnabledChain(RECV_ENABLED_CHAINS_SLOT, integrator, chain);
+        }
+        _bitmapEntry.bitmap |= uint128(1 << index);
         emit RecvAdapterEnabledForChain(integrator, chain, adapter);
     }
 
@@ -290,6 +210,9 @@ abstract contract AdapterRegistry {
                 // Remove the last element
                 adapters.pop();
                 found = true;
+                if (adapters.length == 0) {
+                    _removeEnabledChain(SEND_ENABLED_CHAINS_SLOT, integrator, chain);
+                }
                 break;
             }
             unchecked {
@@ -315,16 +238,18 @@ abstract contract AdapterRegistry {
         onlyRegisteredAdapter(integrator, chain, adapter)
     {
         mapping(address => mapping(address => AdapterInfo)) storage adapterInfos = _getAdapterInfosStorage();
-        mapping(address => mapping(uint16 => _EnabledAdapterBitmap)) storage _enabledAdapterBitmap =
-            _getPerChainRecvAdapterBitmapStorage();
+        _EnabledAdapterBitmap storage _bitmapEntry = _getPerChainRecvAdapterBitmapStorage()[integrator][chain];
 
         uint128 updatedEnabledAdapterBitmap =
-            _enabledAdapterBitmap[integrator][chain].bitmap & uint128(~(1 << adapterInfos[integrator][adapter].index));
+            _bitmapEntry.bitmap & uint128(~(1 << adapterInfos[integrator][adapter].index));
         // ensure that this actually changed the bitmap
-        if (updatedEnabledAdapterBitmap >= _enabledAdapterBitmap[integrator][chain].bitmap) {
+        if (updatedEnabledAdapterBitmap >= _bitmapEntry.bitmap) {
             revert AdapterAlreadyDisabled(adapter);
         }
-        _enabledAdapterBitmap[integrator][chain].bitmap = updatedEnabledAdapterBitmap;
+        _bitmapEntry.bitmap = updatedEnabledAdapterBitmap;
+        if (_bitmapEntry.bitmap == 0) {
+            _removeEnabledChain(RECV_ENABLED_CHAINS_SLOT, integrator, chain);
+        }
 
         emit RecvAdapterDisabledForChain(integrator, chain, adapter);
     }
@@ -493,6 +418,22 @@ abstract contract AdapterRegistry {
         }
     }
 
+    /// @notice Returns all the chains for which the integrator has adapters enabled for sending.
+    /// @dev The chain IDs are not guaranteed to be in order.
+    /// @param integrator The integrator address.
+    /// @return result The chains that have adapters enabled for sending for the given integrator.
+    function getChainsEnabledForSend(address integrator) public view returns (uint16[] memory result) {
+        return _getChainsEnabledStorage(SEND_ENABLED_CHAINS_SLOT)[integrator];
+    }
+
+    /// @notice Returns all the chains for which the integrator has adapters enabled for receiving.
+    /// @dev The chain IDs are not guaranteed to be in order.
+    /// @param integrator The integrator address.
+    /// @return result The chains that have adapters enabled for receiving for the given integrator.
+    function getChainsEnabledForRecv(address integrator) public view returns (uint16[] memory result) {
+        return _getChainsEnabledStorage(RECV_ENABLED_CHAINS_SLOT)[integrator];
+    }
+
     /// @notice Returns the number of enabled receive adapters for the given integrator and chain.
     /// @param integrator The integrator address.
     /// @param chain The Wormhole chain ID for the desired adapters.
@@ -502,6 +443,39 @@ abstract contract AdapterRegistry {
         while (bitmap != 0) {
             bitmap &= bitmap - 1;
             result++;
+        }
+    }
+
+    // =============== Implementations =======================================
+
+    /// @dev It's not an error if the chain is already in the list.
+    function _addEnabledChain(bytes32 tag, address integrator, uint16 chain) internal {
+        uint16[] storage chains = _getChainsEnabledStorage(tag)[integrator];
+        uint256 len = chains.length;
+        for (uint256 idx = 0; (idx < len);) {
+            if (chains[idx] == chain) {
+                return;
+            }
+            unchecked {
+                ++idx;
+            }
+        }
+        chains.push(chain);
+    }
+
+    /// @dev It's not an error if the chain is not in the list.
+    function _removeEnabledChain(bytes32 tag, address integrator, uint16 chain) internal {
+        uint16[] storage chains = _getChainsEnabledStorage(tag)[integrator];
+        uint256 len = chains.length;
+        for (uint256 idx = 0; (idx < len);) {
+            if (chains[idx] == chain) {
+                chains[idx] = chains[len - 1];
+                chains.pop();
+                return;
+            }
+            unchecked {
+                ++idx;
+            }
         }
     }
 }

--- a/evm/src/Endpoint.sol
+++ b/evm/src/Endpoint.sol
@@ -370,12 +370,6 @@ contract Endpoint is IEndpointAdmin, IEndpointIntegrator, IEndpointAdapter, Mess
         _disableRecvAdapter(integrator, chain, adapter);
     }
 
-    /// @inheritdoc IEndpointAdmin
-    function getNumEnabledRecvAdaptersForChain(address integrator, uint16 chain) external view returns (uint8 count) {
-        // Call the AdapterRegistry version.
-        return _getNumEnabledRecvAdaptersForChain(integrator, chain);
-    }
-
     // =============== Message functions =======================================================
 
     /// @inheritdoc IEndpointIntegrator

--- a/evm/src/interfaces/IAdapterRegistry.sol
+++ b/evm/src/interfaces/IAdapterRegistry.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+/// @title AdapterRegistry
+/// @notice This contract is responsible for handling the registration of Adapters.
+interface IAdapterRegistry {
+    /// @dev Information about registered adapters.
+    struct AdapterInfo {
+        // whether this adapter is registered
+        bool registered;
+        uint8 index; // the index into the integrator's adapters array
+    }
+
+    /// @dev Data maintained for each send adapter enabled for an integrator and chain.
+    struct PerSendAdapterInfo {
+        address addr;
+        uint8 index;
+    }
+
+    /// @dev Bitmap encoding the enabled adapters.
+    struct _EnabledAdapterBitmap {
+        uint128 bitmap; // MAX_ADAPTERS = 128
+    }
+
+    // =============== Events ===============================================
+
+    /// @notice Emitted when an adapter is added.
+    /// @dev Topic0
+    ///      0xac0e1ca21680593c8e6fcd302536c12420131dbf0e8ee4b29e529e8a81469f21.
+    /// @param integrator The address of the integrator.
+    /// @param adapter The address of the adapter.
+    /// @param adaptersNum The current number of adapters.
+    event AdapterAdded(address integrator, address adapter, uint8 adaptersNum);
+
+    /// @notice Emitted when a send side adapter is enabled for a chain.
+    /// @dev Topic0
+    ///      0x857691e2cf3b85361da0572fc891250016a03bf7921f5dbb9c34ca3d80591336.
+    /// @param integrator The address of the integrator.
+    /// @param chain The Wormhole chain ID on which this adapter is enabled.
+    /// @param adapter The address of the adapter.
+    event SendAdapterEnabledForChain(address integrator, uint16 chain, address adapter);
+
+    /// @notice Emitted when a receive side adapter is enabled for a chain.
+    /// @dev Topic0
+    ///      0x3649cec96e246496c67087fabed01d3a6c510fec6bfcd3103dd2aedd1b637acc.
+    /// @param integrator The address of the integrator.
+    /// @param chain The Wormhole chain ID on which this adapter is enabled.
+    /// @param adapter The address of the adapter.
+    event RecvAdapterEnabledForChain(address integrator, uint16 chain, address adapter);
+
+    /// @notice Emitted when a send side adapter is removed from the endpoint.
+    /// @dev Topic0
+    ///      0xf5794741500b506041917ff318a1635659dbe538238f4e60979e3f1d29ac021a.
+    /// @param integrator The address of the integrator.
+    /// @param chain The Wormhole chain ID on which this adapter is disabled.
+    /// @param adapter The address of the adapter.
+    event SendAdapterDisabledForChain(address integrator, uint16 chain, address adapter);
+
+    /// @notice Emitted when a receive side adapter is removed from the endpoint.
+    /// @dev Topic0
+    ///      0xcf88609c95c0469dbeb39cfeaa5dcb9b389a6ec8acca2d695dd3feb2f69cffde.
+    /// @param integrator The address of the integrator.
+    /// @param chain The Wormhole chain ID on which this adapter is disabled.
+    /// @param adapter The address of the adapter.
+    event RecvAdapterDisabledForChain(address integrator, uint16 chain, address adapter);
+
+    // =============== Errors ===============================================
+
+    /// @notice Error when the caller is not the adapter.
+    /// @dev Selector: 0xd8aa0b1c.
+    /// @param caller The address of the caller.
+    error CallerNotAdapter(address caller);
+
+    /// @notice Error when the adapter is the zero address.
+    /// @dev Selector: 0x4e2165a2.
+    error InvalidAdapterZeroAddress();
+
+    /// @notice Error when the adapter is disabled.
+    /// @dev Selector: 0x3b4742ca.
+    error AdapterAlreadyDisabled(address adapter);
+
+    /// @notice Error when the number of registered adapters
+    ///         exceeds (MAX_ADAPTERS = 128).
+    /// @dev Selector: 0x5bde12c0.
+    error TooManyAdapters();
+
+    /// @notice Error when attempting to use an unregistered adapter
+    ///         that is not registered.
+    /// @dev Selector: 0xc325a1ea.
+    /// @param adapter The address of the adapter.
+    error NonRegisteredAdapter(address adapter);
+
+    /// @notice Error when attempting to use an incorrect chain.
+    /// @dev Selector: 0x587c94c3.
+    /// @param chain The id of the incorrect chain.
+    error InvalidChain(uint16 chain);
+
+    /// @notice Error when attempting to register an adapter that is already register.
+    /// @dev Selector: 0x2296d41e.
+    /// @param adapter The address of the adapter.
+    error AdapterAlreadyRegistered(address adapter);
+
+    /// @notice Error when attempting to enable an adapter that is already enabled.
+    /// @dev Selector: 0xb7b944b2.
+    /// @param adapter The address of the adapter.
+    error AdapterAlreadyEnabled(address adapter);
+
+    /// @notice Returns the maximum number of adapters allowed.
+    /// @return uint8 The maximum number of adapters allowed.
+    function maxAdapters() external pure returns (uint8);
+
+    /// @notice Returns the enabled send side adapter addresses for the given integrator.
+    /// @param integrator The integrator address.
+    /// @param chain The Wormhole chain ID for the desired adapters.
+    /// @return result The enabled send side adapters for the given integrator and chain.
+    function getSendAdaptersByChain(address integrator, uint16 chain)
+        external
+        view
+        returns (PerSendAdapterInfo[] memory result);
+
+    /// @notice Returns the enabled receive side adapter addresses for the given integrator.
+    /// @param integrator The integrator address.
+    /// @param chain The Wormhole chain ID for the desired adapters.
+    /// @return result The enabled receive side adapters for the given integrator.
+    function getRecvAdaptersByChain(address integrator, uint16 chain) external view returns (address[] memory result);
+
+    /// @notice Returns all the chains for which the integrator has adapters enabled for sending.
+    /// @param integrator The integrator address.
+    /// @return result The chains that have adapters enabled for sending for the given integrator.
+    function getChainsEnabledForSend(address integrator) external view returns (uint16[] memory result);
+
+    /// @notice Returns all the chains for which the integrator has adapters enabled for receiving.
+    /// @param integrator The integrator address.
+    /// @return result The chains that have adapters enabled for receiving for the given integrator.
+    function getChainsEnabledForRecv(address integrator) external view returns (uint16[] memory result);
+
+    /// @notice Returns the number of enabled receive adapters for the given integrator and chain.
+    /// @param integrator The integrator address.
+    /// @param chain The Wormhole chain ID for the desired adapters.
+    /// @return result The number of enabled receive adapters for that chain.
+    function _getNumEnabledRecvAdaptersForChain(address integrator, uint16 chain)
+        external
+        view
+        returns (uint8 result);
+}

--- a/evm/src/interfaces/IAdapterRegistry.sol
+++ b/evm/src/interfaces/IAdapterRegistry.sol
@@ -109,6 +109,23 @@ interface IAdapterRegistry {
     /// @return uint8 The maximum number of adapters allowed.
     function maxAdapters() external pure returns (uint8);
 
+    /// @notice Returns all the registered adapter addresses for the given integrator.
+    /// @param integrator The integrator address.
+    /// @return result The registered adapters for the given integrator.
+    function getAdapters(address integrator) external view returns (address[] memory result);
+
+    /// @notice Returns the queried adapter addresses.
+    /// @param integrator The integrator address.
+    /// @param index The index into the integrator's adapters array.
+    /// @return result The registered adapter address.
+    function getAdapterByIndex(address integrator, uint8 index) external view returns (address result);
+
+    /// @notice Returns the queried adapter's index.
+    /// @param integrator The integrator address.
+    /// @param adapter The address of this adapter.
+    /// @return result The registered adapter index.
+    function getAdapterIndex(address integrator, address adapter) external view returns (uint8 result);
+
     /// @notice Returns the enabled send side adapter addresses for the given integrator.
     /// @param integrator The integrator address.
     /// @param chain The Wormhole chain ID for the desired adapters.
@@ -138,8 +155,5 @@ interface IAdapterRegistry {
     /// @param integrator The integrator address.
     /// @param chain The Wormhole chain ID for the desired adapters.
     /// @return result The number of enabled receive adapters for that chain.
-    function _getNumEnabledRecvAdaptersForChain(address integrator, uint16 chain)
-        external
-        view
-        returns (uint8 result);
+    function getNumEnabledRecvAdaptersForChain(address integrator, uint16 chain) external view returns (uint8 result);
 }

--- a/evm/src/interfaces/IEndpointAdmin.sol
+++ b/evm/src/interfaces/IEndpointAdmin.sol
@@ -54,9 +54,4 @@ interface IEndpointAdmin {
     /// @param adapter The address of the Adapter contract.
     /// @param chain The chain ID of the Adapter contract.
     function disableRecvAdapter(address integrator, uint16 chain, address adapter) external;
-
-    /// @notice Returns the number enabled receive adapters for the given chain.
-    /// @param integrator The address of the integrator contract.
-    /// @param chain The chain ID of the Adapter contract.
-    function getNumEnabledRecvAdaptersForChain(address integrator, uint16 chain) external view returns (uint8 count);
 }

--- a/evm/test/AdapterRegistry.t.sol
+++ b/evm/test/AdapterRegistry.t.sol
@@ -383,34 +383,34 @@ contract AdapterRegistryTest is Test {
     function test_getNumEnabledRecvAdaptersForChain() public {
         address me = address(this);
 
-        require(adapterRegistry._getNumEnabledRecvAdaptersForChain(me, 2) == 0, "Count should be zero to start with");
+        require(adapterRegistry.getNumEnabledRecvAdaptersForChain(me, 2) == 0, "Count should be zero to start with");
 
         // Adding an adapter and enabling it for sending shouldn't change the count.
         adapterRegistry.addAdapter(me, address(0x01));
         adapterRegistry.enableSendAdapter(me, 2, address(0x01));
-        require(adapterRegistry._getNumEnabledRecvAdaptersForChain(me, 2) == 0, "Count should still be zero");
+        require(adapterRegistry.getNumEnabledRecvAdaptersForChain(me, 2) == 0, "Count should still be zero");
 
         // But enabling it for receiving should.
         adapterRegistry.enableRecvAdapter(me, 2, address(0x01));
-        require(adapterRegistry._getNumEnabledRecvAdaptersForChain(me, 2) == 1, "Count should be one");
+        require(adapterRegistry.getNumEnabledRecvAdaptersForChain(me, 2) == 1, "Count should be one");
 
         // Adding and enabling a second adapter should increase the count.
         adapterRegistry.addAdapter(me, address(0x02));
         adapterRegistry.enableRecvAdapter(me, 2, address(0x02));
-        require(adapterRegistry._getNumEnabledRecvAdaptersForChain(me, 2) == 2, "Count should be two");
+        require(adapterRegistry.getNumEnabledRecvAdaptersForChain(me, 2) == 2, "Count should be two");
 
         // Adding and enabling an adapter on another chain should not increase the count.
         adapterRegistry.addAdapter(me, address(0x03));
         adapterRegistry.enableRecvAdapter(me, 3, address(0x03));
-        require(adapterRegistry._getNumEnabledRecvAdaptersForChain(me, 2) == 2, "Count should still be two");
+        require(adapterRegistry.getNumEnabledRecvAdaptersForChain(me, 2) == 2, "Count should still be two");
 
         // Disabling an adapter should decrease the count.
         adapterRegistry.disableRecvAdapter(me, 2, address(0x01));
-        require(adapterRegistry._getNumEnabledRecvAdaptersForChain(me, 2) == 1, "Count should drop to one");
+        require(adapterRegistry.getNumEnabledRecvAdaptersForChain(me, 2) == 1, "Count should drop to one");
 
         // Disabling the last adapter should decrease the count back to zero.
         adapterRegistry.disableRecvAdapter(me, 2, address(0x02));
-        require(adapterRegistry._getNumEnabledRecvAdaptersForChain(me, 2) == 0, "Count should drop to zero");
+        require(adapterRegistry.getNumEnabledRecvAdaptersForChain(me, 2) == 0, "Count should drop to zero");
     }
 
     function test_chainsEnabled() public {
@@ -447,8 +447,17 @@ contract AdapterRegistryTest is Test {
         assertEq(40, chains[1]);
         assertEq(43, chains[2]);
 
-        // Adding something that's already there should do no harm.
+        // WARNING: Adding something that's already there will duplicate it.
         adapterRegistry.addEnabledChainForSend(me, 40);
+        chains = adapterRegistry.getChainsEnabledForSend(me);
+        assertEq(4, chains.length);
+        assertEq(42, chains[0]);
+        assertEq(40, chains[1]);
+        assertEq(43, chains[2]);
+        assertEq(40, chains[3]);
+
+        // Before we start testing remove, clean up the mess we made by getting rid of the duplicate.
+        adapterRegistry.removeEnabledChainForSend(me, 40);
         chains = adapterRegistry.getChainsEnabledForSend(me);
         assertEq(3, chains.length);
         assertEq(42, chains[0]);

--- a/evm/test/Endpoint.t.sol
+++ b/evm/test/Endpoint.t.sol
@@ -765,7 +765,7 @@ contract EndpointTest is Test {
         require(price == 300, "Triple price is wrong");
     }
 
-    function testgetNumEnabledRecvAdaptersForChain() public view {
+    function test_getNumEnabledRecvAdaptersForChain() public view {
         // This function is actually tested in the AdapterRegistry tests. Just call it here for code coverage.
         require(endpoint.getNumEnabledRecvAdaptersForChain(address(0x01), 2) == 0, "Count should be zero");
     }

--- a/evm/test/Endpoint.t.sol
+++ b/evm/test/Endpoint.t.sol
@@ -765,7 +765,7 @@ contract EndpointTest is Test {
         require(price == 300, "Triple price is wrong");
     }
 
-    function test_getNumEnabledRecvAdaptersForChain() public view {
+    function testgetNumEnabledRecvAdaptersForChain() public view {
         // This function is actually tested in the AdapterRegistry tests. Just call it here for code coverage.
         require(endpoint.getNumEnabledRecvAdaptersForChain(address(0x01), 2) == 0, "Count should be zero");
     }

--- a/evm/test/Endpoint.t.sol
+++ b/evm/test/Endpoint.t.sol
@@ -6,6 +6,7 @@ import "forge-std/console.sol";
 import "../src/libraries/UniversalAddress.sol";
 import {Endpoint} from "../src/Endpoint.sol";
 import {AdapterRegistry} from "../src/AdapterRegistry.sol";
+import "../src/interfaces/IAdapterRegistry.sol";
 import {IAdapter} from "../src/interfaces/IAdapter.sol";
 import "../src/libraries/AdapterInstructions.sol";
 
@@ -220,7 +221,7 @@ contract EndpointTest is Test {
         // The admin can add an adapter.
         vm.startPrank(admin);
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.AdapterAdded(integrator, taddr1, 1);
+        emit IAdapterRegistry.AdapterAdded(integrator, taddr1, 1);
         endpoint.addAdapter(integrator, taddr1);
 
         // Others cannot add an adapter.
@@ -230,27 +231,27 @@ contract EndpointTest is Test {
 
         // Can't register the adapter twice.
         vm.startPrank(admin);
-        vm.expectRevert(abi.encodeWithSelector(AdapterRegistry.AdapterAlreadyRegistered.selector, taddr1));
+        vm.expectRevert(abi.encodeWithSelector(IAdapterRegistry.AdapterAlreadyRegistered.selector, taddr1));
         endpoint.addAdapter(integrator, taddr1);
         // Can't enable the adapter twice.
         endpoint.enableSendAdapter(integrator, 1, taddr1);
-        vm.expectRevert(abi.encodeWithSelector(AdapterRegistry.AdapterAlreadyEnabled.selector, taddr1));
+        vm.expectRevert(abi.encodeWithSelector(IAdapterRegistry.AdapterAlreadyEnabled.selector, taddr1));
         endpoint.enableSendAdapter(integrator, 1, taddr1);
 
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.AdapterAdded(integrator, taddr2, 2);
+        emit IAdapterRegistry.AdapterAdded(integrator, taddr2, 2);
         endpoint.addAdapter(integrator, taddr2);
-        AdapterRegistry.PerSendAdapterInfo[] memory adapters = endpoint.getSendAdaptersByChain(integrator, 1);
+        IAdapterRegistry.PerSendAdapterInfo[] memory adapters = endpoint.getSendAdaptersByChain(integrator, 1);
         require(adapters.length == 1, "Wrong number of adapters enabled on chain one, should be 1");
         // Enable another adapter on chain one and one on chain two.
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.SendAdapterEnabledForChain(integrator, 1, taddr2);
+        emit IAdapterRegistry.SendAdapterEnabledForChain(integrator, 1, taddr2);
         endpoint.enableSendAdapter(integrator, 1, taddr2);
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.AdapterAdded(integrator, taddr3, 3);
+        emit IAdapterRegistry.AdapterAdded(integrator, taddr3, 3);
         endpoint.addAdapter(integrator, taddr3);
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.SendAdapterEnabledForChain(integrator, 2, taddr3);
+        emit IAdapterRegistry.SendAdapterEnabledForChain(integrator, 2, taddr3);
         endpoint.enableSendAdapter(integrator, 2, taddr3);
 
         // And verify they got set properly.
@@ -265,7 +266,7 @@ contract EndpointTest is Test {
         require(adapters[0].addr == taddr3, "Wrong adapter one on chain two");
         require(adapters[0].index == 2, "Wrong adapter index one on chain two");
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.SendAdapterDisabledForChain(integrator, 2, taddr3);
+        emit IAdapterRegistry.SendAdapterDisabledForChain(integrator, 2, taddr3);
         endpoint.disableSendAdapter(integrator, 2, taddr3);
         require(adapters.length == 1, "Wrong number of adapters enabled on chain two");
     }
@@ -294,7 +295,7 @@ contract EndpointTest is Test {
         // The admin can add an adapter.
         vm.startPrank(admin);
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.AdapterAdded(integrator, taddr1, 1);
+        emit IAdapterRegistry.AdapterAdded(integrator, taddr1, 1);
         endpoint.addAdapter(integrator, taddr1);
 
         // Others cannot add an adapter.
@@ -304,29 +305,29 @@ contract EndpointTest is Test {
 
         // Can't register the adapter twice.
         vm.startPrank(admin);
-        vm.expectRevert(abi.encodeWithSelector(AdapterRegistry.AdapterAlreadyRegistered.selector, taddr1));
+        vm.expectRevert(abi.encodeWithSelector(IAdapterRegistry.AdapterAlreadyRegistered.selector, taddr1));
         endpoint.addAdapter(integrator, taddr1);
         // Can't enable the adapter twice.
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.RecvAdapterEnabledForChain(integrator, 1, taddr1);
+        emit IAdapterRegistry.RecvAdapterEnabledForChain(integrator, 1, taddr1);
         endpoint.enableRecvAdapter(integrator, 1, taddr1);
-        vm.expectRevert(abi.encodeWithSelector(AdapterRegistry.AdapterAlreadyEnabled.selector, taddr1));
+        vm.expectRevert(abi.encodeWithSelector(IAdapterRegistry.AdapterAlreadyEnabled.selector, taddr1));
         endpoint.enableRecvAdapter(integrator, 1, taddr1);
 
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.AdapterAdded(integrator, taddr2, 2);
+        emit IAdapterRegistry.AdapterAdded(integrator, taddr2, 2);
         endpoint.addAdapter(integrator, taddr2);
         address[] memory adapters = endpoint.getRecvAdaptersByChain(integrator, 1);
         require(adapters.length == 1, "Wrong number of adapters enabled on chain one, should be 1");
         // Enable another adapter on chain one and one on chain two.
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.RecvAdapterEnabledForChain(integrator, 1, taddr2);
+        emit IAdapterRegistry.RecvAdapterEnabledForChain(integrator, 1, taddr2);
         endpoint.enableRecvAdapter(integrator, 1, taddr2);
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.AdapterAdded(integrator, taddr3, 3);
+        emit IAdapterRegistry.AdapterAdded(integrator, taddr3, 3);
         endpoint.addAdapter(integrator, taddr3);
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.RecvAdapterEnabledForChain(integrator, 2, taddr3);
+        emit IAdapterRegistry.RecvAdapterEnabledForChain(integrator, 2, taddr3);
         endpoint.enableRecvAdapter(integrator, 2, taddr3);
 
         // And verify they got set properly.
@@ -362,22 +363,22 @@ contract EndpointTest is Test {
         // Now enable some adapters.
         vm.startPrank(admin);
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.AdapterAdded(integrator, address(adapter1), 1);
+        emit IAdapterRegistry.AdapterAdded(integrator, address(adapter1), 1);
         endpoint.addAdapter(integrator, address(adapter1));
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.SendAdapterEnabledForChain(integrator, 2, address(adapter1));
+        emit IAdapterRegistry.SendAdapterEnabledForChain(integrator, 2, address(adapter1));
         endpoint.enableSendAdapter(integrator, 2, address(adapter1));
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.AdapterAdded(integrator, address(adapter2), 2);
+        emit IAdapterRegistry.AdapterAdded(integrator, address(adapter2), 2);
         endpoint.addAdapter(integrator, address(adapter2));
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.SendAdapterEnabledForChain(integrator, 2, address(adapter2));
+        emit IAdapterRegistry.SendAdapterEnabledForChain(integrator, 2, address(adapter2));
         endpoint.enableSendAdapter(integrator, 2, address(adapter2));
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.AdapterAdded(integrator, address(adapter3), 3);
+        emit IAdapterRegistry.AdapterAdded(integrator, address(adapter3), 3);
         endpoint.addAdapter(integrator, address(adapter3));
         vm.expectEmit(true, true, false, true);
-        emit AdapterRegistry.SendAdapterEnabledForChain(integrator, 3, address(adapter3));
+        emit IAdapterRegistry.SendAdapterEnabledForChain(integrator, 3, address(adapter3));
         endpoint.enableSendAdapter(integrator, 3, address(adapter3));
 
         // Only an integrator can call send.
@@ -418,7 +419,7 @@ contract EndpointTest is Test {
         require(adapter2.getMessagesSent() == 2, "Failed to send second message on adapter 2");
         require(adapter3.getMessagesSent() == 0, "Should not have sent second message on adapter 3");
 
-        vm.expectRevert(abi.encodeWithSelector(AdapterRegistry.InvalidChain.selector, zeroChain));
+        vm.expectRevert(abi.encodeWithSelector(IAdapterRegistry.InvalidChain.selector, zeroChain));
         sequence =
             endpoint.sendMessage(zeroChain, UniversalAddressLibrary.fromAddress(userA), payloadHash, refundAddr, insts);
         require(sequence == 0, "Failed sequence number is wrong"); // 0 because of the revert


### PR DESCRIPTION
This PR enhances the `AdapterRegistry` to keep track of the chains for which an integrator has adapters enabled for sending or receiving (separate lists for both). This information will be useful for migration scenarios. Also, NTT with MM will need to know about chains enabled for receiving.

This PR also creates an `IAdapterRegistry` so that applications do not need to import `AdapterRegistry.sol`.

Also, since we now have `IAdapterRegistry`, I moved `_getNumEnabledRecvAdaptersForChain` from `IEndpointAdmin` to `IAdapterRegistry` and renamed it to remove the underscore (sinces it's external / public).